### PR TITLE
Build Script Typo

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "sideEffects": false,
   "scripts": {
     "build": "pnpm run build:css && remix build",
-    "buid:css": "tailwindcss -m -i ./styles/app.css -o app/styles/app.css",
+    "build:css": "tailwindcss -m -i ./styles/app.css -o app/styles/app.css",
     "dev": "concurrently \"pnpm run dev:css\" \"remix dev\"",
     "dev:css": "tailwindcss -w -i ./styles/app.css -o app/styles/app.css",
     "typecheck": "tsc"


### PR DESCRIPTION
# Changes
- script name: ‘buid:css’ -> ‘build:css’